### PR TITLE
documentation mismatch in kinematic_constraint.h

### DIFF
--- a/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
+++ b/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
@@ -339,7 +339,7 @@ MOVEIT_CLASS_FORWARD(OrientationConstraint);
  * This class expresses an orientation constraint on a particular
  * link.  The constraint is specified in terms of a quaternion, with
  * tolerances on X,Y, and Z axes.  The rotation difference is computed
- * based on the ZXZ Euler angle formulation.  The header on the
+ * based on the XYZ Euler angle formulation (intrinsic rotations).  The header on the
  * quaternion can be specified in terms of either a fixed frame or a
  * mobile frame.  The type value will return ORIENTATION_CONSTRAINT.
  *


### PR DESCRIPTION
### Description

There is a mismatch between the documentation and the implementation.
Implementation uses XYZ Euler angles, documentation says ZXZ.

The implementation can be seen in [kinematic_constraint.cpp](https://github.com/ros-planning/moveit/blob/acead73aae0df309eaeb1a71ebe3f0bffce8efba/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp#L601) and in [default_constraint_samplers.cpp](https://github.com/ros-planning/moveit/blob/acead73aae0df309eaeb1a71ebe3f0bffce8efba/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp#L479).

I don't think the checklist below is relevant for such a small change (only a single line).
Is such a small change even worth a pull request?

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
