### PR TITLE
Rewrite function "copyJointToOMPLState" in ompl interface to make it more readable?

### DIFF
--- a/moveit_planners/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
@@ -339,10 +339,11 @@ void ompl_interface::ModelBasedStateSpace::copyJointToOMPLState(ompl::base::Stat
                                                                 int ompl_state_joint_index) const
 {
   // Copy one joint (multiple variables possibly)
-  memcpy(getValueAddressAtIndex(state, ompl_state_joint_index),
-         robot_state.getVariablePositions() + joint_model->getFirstVariableIndex() * sizeof(double),
-         joint_model->getVariableCount() * sizeof(double));
-
+  for (std::size_t offset = 0; offset < joint_model->getVariableCount(); ++offset)
+  {
+    *getValueAddressAtIndex(state, ompl_state_joint_index + offset) =
+        robot_state.getVariablePosition(joint_model->getFirstVariableIndex() + offset);
+  }
   // clear any cached info (such as validity known or not)
   state->as<StateType>()->clearKnownInformation();
 }


### PR DESCRIPTION
### Description

Just a small suggestion to make to code more readable and easier to debug.
I do not know whether it has performance implications.

#### Tests?
I [tested](https://github.com/ros-planning/moveit/blob/52d9f7d08acdfd7a3050ed931b9949395eb3ac44/moveit_planners/ompl/ompl_interface/test/test_constrained_planning_state_space.cpp#L235) the same code in another branch, but only for joint models with a single degree of freedom. If this change seems like a good idea, I can add a test here that covers different types of joints.

#### What the code does
An attempt at visualizing what I think should happen:
(The | ... | represent joint values for fixed joints (or mimic joints?) that are not relevant for OMPL)

Robot model memory (array of doubles):

`| x1 | x2 | ... | ... | y1 | y2 | y3  | ... | ... | ... | z1 | .. |`
                          
Copies into OMPL state memory (also an array of doubles)
`| x1 | x2 |  y1 | y2 | y3  | z1 |`


### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
