### PR TITLE
Remove eigen_conversions from ompl

### DIFF
--- a/moveit_planners/ompl/CMakeLists.txt
+++ b/moveit_planners/ompl/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(catkin REQUIRED COMPONENTS
   rosconsole
   pluginlib
   tf2_ros
+  tf2_eigen
   dynamic_reconfigure
   )
 

--- a/moveit_planners/ompl/ompl_interface/CMakeLists.txt
+++ b/moveit_planners/ompl/ompl_interface/CMakeLists.txt
@@ -54,12 +54,11 @@ if(CATKIN_ENABLE_TESTING)
 
   # Unfortunately it is not possible to test the planning context manager without introducing a ROS dependency.
   find_package(rostest REQUIRED)
-  find_package(eigen_conversions REQUIRED)
 
   catkin_add_gtest(test_state_validity_checker test/test_state_validity_checker.cpp)
   target_link_libraries(test_state_validity_checker ${MOVEIT_LIB_NAME} ${OMPL_LIBRARIES} ${catkin_LIBRARIES})
   set_target_properties(test_state_validity_checker PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}")
-  
+
   catkin_add_gtest(test_constrained_planning_state_space test/test_constrained_planning_state_space.cpp)
   target_link_libraries(test_constrained_planning_state_space ${MOVEIT_LIB_NAME} ${OMPL_LIBRARIES} ${catkin_LIBRARIES})
   set_target_properties(test_constrained_planning_state_space PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}")
@@ -74,5 +73,5 @@ if(CATKIN_ENABLE_TESTING)
   add_rostest_gtest(test_planning_context_manager
     test/test_planning_context_manager.test
     test/test_planning_context_manager.cpp)
-  target_link_libraries(test_planning_context_manager ${MOVEIT_LIB_NAME} ${OMPL_LIBRARIES} ${catkin_LIBRARIES} ${eigen_conversions_LIBRARIES})
+  target_link_libraries(test_planning_context_manager ${MOVEIT_LIB_NAME} ${OMPL_LIBRARIES} ${catkin_LIBRARIES})
 endif()

--- a/moveit_planners/ompl/ompl_interface/src/detail/ompl_constraints.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/ompl_constraints.cpp
@@ -39,7 +39,7 @@
 #include <moveit/ompl_interface/detail/threadsafe_state_storage.h>
 #include <moveit/robot_model/robot_model.h>
 #include <moveit_msgs/Constraints.h>
-#include <eigen_conversions/eigen_msg.h>
+#include <tf2_eigen/tf2_eigen.h>
 
 namespace ompl_interface
 {
@@ -176,8 +176,8 @@ void BoxConstraint::parseConstraintMsg(const moveit_msgs::Constraints& constrain
   geometry_msgs::Point position =
       constraints.position_constraints.at(0).constraint_region.primitive_poses.at(0).position;
   target_position_ << position.x, position.y, position.z;
-  tf::quaternionMsgToEigen(constraints.position_constraints.at(0).constraint_region.primitive_poses.at(0).orientation,
-                           target_orientation_);
+  tf2::fromMsg(constraints.position_constraints.at(0).constraint_region.primitive_poses.at(0).orientation,
+               target_orientation_);
 
   link_name_ = constraints.position_constraints.at(0).link_name;
   ROS_DEBUG_STREAM_NAMED(LOGNAME, "Position constraints applied to link: " << link_name_);
@@ -229,8 +229,8 @@ void EqualityPositionConstraint::parseConstraintMsg(const moveit_msgs::Constrain
   geometry_msgs::Point position =
       constraints.position_constraints.at(0).constraint_region.primitive_poses.at(0).position;
   target_position_ << position.x, position.y, position.z;
-  tf::quaternionMsgToEigen(constraints.position_constraints.at(0).constraint_region.primitive_poses.at(0).orientation,
-                           target_orientation_);
+  tf2::fromMsg(constraints.position_constraints.at(0).constraint_region.primitive_poses.at(0).orientation,
+               target_orientation_);
 
   ROS_DEBUG_STREAM_NAMED(LOGNAME, "Equality constraint on x-position? " << (is_dim_constrained_[0] ? "yes" : "no"));
   ROS_DEBUG_STREAM_NAMED(LOGNAME, "Equality constraint on y-position? " << (is_dim_constrained_[1] ? "yes" : "no"));

--- a/moveit_planners/ompl/ompl_interface/test/test_ompl_constraints.cpp
+++ b/moveit_planners/ompl/ompl_interface/test/test_ompl_constraints.cpp
@@ -51,7 +51,6 @@
 
 #include <gtest/gtest.h>
 #include <Eigen/Dense>
-#include <eigen_conversions/eigen_msg.h>
 
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_state/robot_state.h>

--- a/moveit_planners/ompl/ompl_interface/test/test_planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/test/test_planning_context_manager.cpp
@@ -54,8 +54,6 @@
 
 #include <gtest/gtest.h>
 
-#include <eigen_conversions/eigen_msg.h>
-
 #include <moveit/ompl_interface/planning_context_manager.h>
 #include <moveit/planning_scene/planning_scene.h>
 #include <moveit/planning_interface/planning_request.h>
@@ -65,6 +63,8 @@
 
 #include <moveit/ompl_interface/parameterization/joint_space/joint_model_state_space.h>
 #include <moveit/ompl_interface/parameterization/joint_space/constrained_planning_state_space.h>
+
+#include <tf2_eigen/tf2_eigen.h>
 
 /** \brief Generic implementation of the tests that can be executed on different robots. **/
 class TestPlanningContext : public ompl_interface_testing::LoadTestRobot, public testing::Test
@@ -132,8 +132,7 @@ public:
     // create path constraints around start state,  to make sure they are satisfied
     robot_state_->setJointGroupPositions(joint_model_group_, start);
     Eigen::Isometry3d ee_pose = robot_state_->getGlobalLinkTransform(ee_link_name_);
-    geometry_msgs::Quaternion ee_orientation;
-    tf::quaternionEigenToMsg(Eigen::Quaterniond(ee_pose.rotation()), ee_orientation);
+    const geometry_msgs::Quaternion ee_orientation = tf2::toMsg(Eigen::Quaterniond(ee_pose.rotation()));
 
     // setup the planning context manager
     ompl_interface::PlanningContextManager pcm(robot_model_, constraint_sampler_manager_);
@@ -239,8 +238,7 @@ public:
     // create path constraints around start state, to make sure they are satisfied
     robot_state_->setJointGroupPositions(joint_model_group_, start);
     Eigen::Isometry3d ee_pose = robot_state_->getGlobalLinkTransform(ee_link_name_);
-    // geometry_msgs::Quaternion ee_orientation;
-    // tf::quaternionEigenToMsg(Eigen::Quaterniond(ee_pose.rotation()), ee_orientation);
+    // const geometry_msgs::Quaternion ee_orientation = tf2::toMsg(Eigen::Quaterniond(ee_pose.rotation()));
     // request.path_constraints.orientation_constraints.push_back(createOrientationConstraint(ee_orientation));
     request.path_constraints.position_constraints.push_back(createPositionConstraint(
         { ee_pose.translation().x(), ee_pose.translation().y(), ee_pose.translation().z() }, { 1.0, 1.0, 1.0 }));

--- a/moveit_planners/ompl/package.xml
+++ b/moveit_planners/ompl/package.xml
@@ -22,6 +22,7 @@
   <depend>dynamic_reconfigure</depend>
   <depend>rosconsole</depend>
   <depend>roscpp</depend>
+  <depend>tf2_eigen</depend>
   <depend>tf2_ros</depend>
   <depend version_gte="1.11.2">pluginlib</depend>
 
@@ -32,7 +33,6 @@
   <test_depend>moveit_resources_panda_moveit_config</test_depend>
   <test_depend>rosunit</test_depend>
   <test_depend>rostest</test_depend>
-  <test_depend>eigen_conversions</test_depend>
 
   <export>
     <moveit_core plugin="${prefix}/ompl_interface_plugin_description.xml"/>


### PR DESCRIPTION
### Description

eigen_conversions and friends are currently replaced by tf2_eigen. See also ros-planning/moveit#2472

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
